### PR TITLE
Fixing concurrent modification error when removing expired observations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -86,14 +86,17 @@ public class Observation {
     public static void startExpiredObservationScanningTask(Observations plugin) {
         Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
             Utils.debug("Scanning for expired observations...");
-            long count = observations.stream()
+            List<Observation> toRemove = observations.stream()
                     .filter(Observation::hasExpired)
                     .filter(v -> !v.isTemporary())
-                    .peek(Observation::deleteObservation)
-                    .count();
+                    .collect(Collectors.toList());
+
+            int count = toRemove.size();
+            toRemove.forEach(observation -> observation.deleteObservation());
+
             if (count > 0) {
                 plugin.getQueryer().makeExpiredObservationsInactive(dbCount -> {
-                    Utils.debug("Removed " + count + " expired observation(s). (" + dbCount + ") from database");
+                    Utils.debug("Removed " + count + " expired observation(s). (" + dbCount + " from the database)");
                 });
             }
         }, 20 * 60, 20 * 60);


### PR DESCRIPTION
There was a concurrent modification error occurring when removing expired observations. This PR fixes this.