### PR TITLE
Fix deprecated SQL driver warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.2.1</version>
+	<version>2.2.2</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/src/main/java/edu/whimc/observations/utils/sql/MySQLConnection.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/MySQLConnection.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 
 public class MySQLConnection {
 
-    public static final String DRIVER_CLASS = "com.mysql.jdbc.Driver";
     public static final String URL_TEMPLATE = "jdbc:mysql://%s:%s/%s";
 
     private Connection connection;
@@ -48,10 +47,8 @@ public class MySQLConnection {
             if (this.connection != null && !this.connection.isClosed()) {
                 return this.connection;
             }
-
-            Class.forName(DRIVER_CLASS);
             this.connection = DriverManager.getConnection(this.url, this.username, this.password);
-        } catch (SQLException | ClassNotFoundException e) {
+        } catch (SQLException ignored) {
             return null;
         }
 


### PR DESCRIPTION
Resolves #26 

We no longer have to manually load the MySQL Driver we use - it is automatically registered using a newer one.