### PR TITLE
Added color removal and fixed duplicate observation bug for templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.4.6</version>
+	<version>2.5.0</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 			<groupId>com.github.PikaMug.Quests</groupId>
 			<artifactId>quests-main</artifactId>
 			<version>4.0.8</version>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Add ProtocolLib to the build-->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.4.5</version>
+	<version>2.4.6</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
+++ b/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
@@ -31,20 +31,6 @@ public class ObserveCommand implements CommandExecutor, TabCompleter {
         this.plugin = plugin;
     }
 
-    public static void makeObservation(Observations plugin, String observation, Player player) {
-        int days = plugin.getConfig().getInt("expiration-days");
-        Timestamp expiration = Timestamp.from(Instant.now().plus(days, ChronoUnit.DAYS));
-
-        Observation obs = Observation.createObservation(plugin, player, player.getLocation(), observation, expiration, null);
-        Utils.msg(player,
-                "&7Your observation has been placed:",
-                "  &8\"&f&l" + observation + "&8\"");
-
-        // Call custom event
-        ObserveEvent observeEvent = new ObserveEvent(obs, player);
-        Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getServer().getPluginManager().callEvent(observeEvent));
-    }
-
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
@@ -67,7 +53,7 @@ public class ObserveCommand implements CommandExecutor, TabCompleter {
         }
 
         String text = StringUtils.join(args, " ");
-        makeObservation(this.plugin, text, player);
+        Observation.createObservationEventWithCurrentTime(this.plugin, text, player, null);
         return true;
     }
 

--- a/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
+++ b/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
@@ -2,10 +2,8 @@ package edu.whimc.observations.commands;
 
 import edu.whimc.observations.Observations;
 import edu.whimc.observations.models.Observation;
-import edu.whimc.observations.models.ObserveEvent;
 import edu.whimc.observations.utils.Utils;
 import org.apache.commons.lang.StringUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -13,9 +11,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -53,7 +48,7 @@ public class ObserveCommand implements CommandExecutor, TabCompleter {
         }
 
         String text = StringUtils.join(args, " ");
-        Observation.createObservationEventWithCurrentTime(this.plugin, text, player, null);
+        Observation.createPlayerObservation(this.plugin, player, text, null);
         return true;
     }
 

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -68,7 +68,15 @@ public class Observation {
         });
     }
 
-    public static Observation createObservationEventWithCurrentTime(Observations plugin, String observation, Player player, ObservationTemplate template) {
+    /**
+     * Creates a new observation and calls a new observe event with current time and configured expiration
+     * @param plugin Observations plugin being used
+     * @param player Player making the observation
+     * @param observation Text of the observation being made
+     * @param template The observation template being used
+     * @return New observation being created
+     */
+    public static Observation createPlayerObservation(Observations plugin, Player player, String observation, ObservationTemplate template) {
         int days = plugin.getConfig().getInt("expiration-days");
         Timestamp expiration = Timestamp.from(Instant.now().plus(days, ChronoUnit.DAYS));
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
@@ -2,6 +2,7 @@ package edu.whimc.observations.observetemplate.gui;
 
 import edu.whimc.observations.Observations;
 import edu.whimc.observations.commands.ObserveCommand;
+import edu.whimc.observations.models.Observation;
 import edu.whimc.observations.observetemplate.TemplateManager;
 import edu.whimc.observations.observetemplate.models.ObservationTemplate;
 import edu.whimc.observations.observetemplate.models.ObservationType;
@@ -108,7 +109,7 @@ public final class TemplateGui implements Listener {
                                     if (response.isEmpty()) {
                                         return false;
                                     }
-                                    ObserveCommand.makeObservation(this.plugin, response, signPlayer);
+                                    Observation.createObservationEventWithCurrentTime(this.plugin, response, signPlayer, null);
                                     return true;
                                 })
                                 .open(p);

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
@@ -18,7 +18,6 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.ChatColor;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -109,7 +108,7 @@ public final class TemplateGui implements Listener {
                                     if (response.isEmpty()) {
                                         return false;
                                     }
-                                    Observation.createObservationEventWithCurrentTime(this.plugin, response, signPlayer, null);
+                                    Observation.createPlayerObservation(this.plugin, signPlayer, response, null);
                                     return true;
                                 })
                                 .open(p);

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
@@ -203,7 +203,7 @@ public class TemplateSelection implements Listener {
         // Create observation object for custom event
         int days = plugin.getConfig().getInt("expiration-days");
         Timestamp expiration = Timestamp.from(Instant.now().plus(days, ChronoUnit.DAYS));
-        Observation obs = Observation.createObservation(plugin, player, player.getLocation(), filledIn, expiration, null);
+        Observation obs = Observation.createObservation(plugin, player, player.getLocation(), filledIn, expiration, this.template);
         
         // Call custom event
         ObserveEvent observeEvent = new ObserveEvent(obs, player);
@@ -254,7 +254,7 @@ public class TemplateSelection implements Listener {
                 int days = this.plugin.getConfig().getInt("expiration-days");
                 Timestamp expiration = Timestamp.from(Instant.now().plus(days, ChronoUnit.DAYS));
 
-                Observation.createObservation(this.plugin, player, player.getLocation(), text, expiration, this.template);
+                //Observation.createObservation(this.plugin, player, player.getLocation(), text, expiration, this.template);
 
                 Utils.msg(player,
                         "&7Your observation has been placed:",

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
@@ -5,7 +5,6 @@ import edu.whimc.observations.commands.ObserveCommand;
 import edu.whimc.observations.libraries.CenteredText;
 import edu.whimc.observations.libraries.SpigotCallback;
 import edu.whimc.observations.models.Observation;
-import edu.whimc.observations.models.ObserveEvent;
 import edu.whimc.observations.observetemplate.models.ObservationPrompt;
 import edu.whimc.observations.observetemplate.models.ObservationTemplate;
 import edu.whimc.observations.utils.Utils;
@@ -21,9 +20,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -242,7 +238,7 @@ public class TemplateSelection implements Listener {
         if (withConfirm) {
             Consumer<Player> confirmCallback = p -> {
                 String text = Utils.color(getFilledInPrompt());
-                Observation.createObservationEventWithCurrentTime(this.plugin, text, player, this.template);
+                Observation.createPlayerObservation(this.plugin, player, text, this.template);
                 destroySelection();
             };
 

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
@@ -199,15 +199,6 @@ public class TemplateSelection implements Listener {
             this.responseIndex -= 1;
             doStage(TemplateSelectionStage.SELECT_RESPONSE);
         });
-        
-        // Create observation object for custom event
-        int days = plugin.getConfig().getInt("expiration-days");
-        Timestamp expiration = Timestamp.from(Instant.now().plus(days, ChronoUnit.DAYS));
-        Observation obs = Observation.createObservation(plugin, player, player.getLocation(), filledIn, expiration, this.template);
-        
-        // Call custom event
-        ObserveEvent observeEvent = new ObserveEvent(obs, player);
-        Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getServer().getPluginManager().callEvent(observeEvent));
     }
 
     private String getFilledInPrompt() {
@@ -251,14 +242,7 @@ public class TemplateSelection implements Listener {
         if (withConfirm) {
             Consumer<Player> confirmCallback = p -> {
                 String text = Utils.color(getFilledInPrompt());
-                int days = this.plugin.getConfig().getInt("expiration-days");
-                Timestamp expiration = Timestamp.from(Instant.now().plus(days, ChronoUnit.DAYS));
-
-                //Observation.createObservation(this.plugin, player, player.getLocation(), text, expiration, this.template);
-
-                Utils.msg(player,
-                        "&7Your observation has been placed:",
-                        "  &8\"&f&l" + text + "&8\"");
+                Observation.createObservationEventWithCurrentTime(this.plugin, text, player, this.template);
                 destroySelection();
             };
 

--- a/src/main/java/edu/whimc/observations/utils/sql/Queryer.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/Queryer.java
@@ -53,6 +53,7 @@ public class Queryer {
             "UPDATE whimc_observations " +
                     "SET active=0 " +
                     "WHERE active=1 AND world=?";
+
     private static final String QUERY_MAKE_OBSERVATIONS_INACTIVE =
             "UPDATE whimc_observations " +
                     "SET active=0 " +
@@ -133,14 +134,7 @@ public class Queryer {
         statement.setBoolean(11, true);
         statement.setLong(12, obs.getExpiration().getTime());
         statement.setString(13, category);
-        String obsNoColorWithAmpersand = ChatColor.stripColor(obs.getObservation());
-        String[] splitObsNoColor = obsNoColorWithAmpersand.split("&");
-        String obsNoColor = splitObsNoColor[0];
-        for(int k = 1; k < splitObsNoColor.length; k++)
-        {
-            obsNoColor += splitObsNoColor[k].substring(1);
-        }
-        statement.setString(14, obsNoColor);
+        statement.setString(14, ChatColor.stripColor(Utils.color(obs.getObservation())));
         return statement;
     }
 

--- a/src/main/java/edu/whimc/observations/utils/sql/Queryer.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/Queryer.java
@@ -8,6 +8,7 @@ import edu.whimc.observations.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.ChatColor;
 
 import java.sql.*;
 import java.util.function.Consumer;
@@ -24,8 +25,8 @@ public class Queryer {
      */
     private static final String QUERY_SAVE_OBSERVATION =
             "INSERT INTO whimc_observations " +
-                    "(time, uuid, username, world, x, y, z, yaw, pitch, observation, active, expiration, category) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                    "(time, uuid, username, world, x, y, z, yaw, pitch, observation, active, expiration, category, observation_color_stripped) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
     /**
      * Query for getting all observations from the database.
@@ -132,7 +133,14 @@ public class Queryer {
         statement.setBoolean(11, true);
         statement.setLong(12, obs.getExpiration().getTime());
         statement.setString(13, category);
-
+        String obsNoColorWithAmpersand = ChatColor.stripColor(obs.getObservation());
+        String[] splitObsNoColor = obsNoColorWithAmpersand.split("&");
+        String obsNoColor = splitObsNoColor[0];
+        for(int k = 1; k < splitObsNoColor.length; k++)
+        {
+            obsNoColor += splitObsNoColor[k].substring(1);
+        }
+        statement.setString(14, obsNoColor);
         return statement;
     }
 

--- a/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_2.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_2.java
@@ -16,10 +16,12 @@ public class Schema_2 extends SchemaVersion {
     }
 
     @Override
-    protected void migrateRoutine(Connection connection) throws SQLException {
+    protected void migrateRoutine(Connection connection) {
         try (PreparedStatement statement = connection.prepareStatement(ADD_CATEGORY)) {
             statement.execute();
+        }catch (SQLException e){
         }
+
     }
 
 }

--- a/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
@@ -10,17 +10,12 @@ public class Schema_4 extends SchemaVersion {
 
     private static final String ADD_CATEGORY =
             "ALTER TABLE whimc_observations ADD COLUMN observation_color_stripped TEXT;";
-
-    /**
-     * Query to update existing observations with an uncolored version
-     */
+    
     private static final String QUERY_UPDATE_OBSERVATION_NO_COLOR =
             "UPDATE whimc_observations " +
                     "SET observation_color_stripped=?" +
                     "WHERE rowid=?";
-    /**
-     * Query for getting all observations from the database.
-     */
+
     private static final String QUERY_GET_OBSERVATIONS =
             "SELECT * " +
                     "FROM whimc_observations " +
@@ -34,6 +29,7 @@ public class Schema_4 extends SchemaVersion {
     protected void migrateRoutine(Connection connection) throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(ADD_CATEGORY)) {
             statement.execute();
+        }catch (SQLException e){
         }
 
         try (PreparedStatement statement = connection.prepareStatement(QUERY_UPDATE_OBSERVATION_NO_COLOR)) {

--- a/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
@@ -2,9 +2,7 @@ package edu.whimc.observations.utils.sql.migration.schemas;
 
 import edu.whimc.observations.utils.sql.migration.SchemaVersion;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import java.sql.*;
 
 public class Schema_4 extends SchemaVersion {
 

--- a/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
@@ -1,6 +1,8 @@
 package edu.whimc.observations.utils.sql.migration.schemas;
 
+import edu.whimc.observations.utils.Utils;
 import edu.whimc.observations.utils.sql.migration.SchemaVersion;
+import org.bukkit.ChatColor;
 
 import java.sql.*;
 
@@ -8,6 +10,21 @@ public class Schema_4 extends SchemaVersion {
 
     private static final String ADD_CATEGORY =
             "ALTER TABLE whimc_observations ADD COLUMN observation_color_stripped TEXT;";
+
+    /**
+     * Query to update existing observations with an uncolored version
+     */
+    private static final String QUERY_UPDATE_OBSERVATION_NO_COLOR =
+            "UPDATE whimc_observations " +
+                    "SET observation_color_stripped=?" +
+                    "WHERE rowid=?";
+    /**
+     * Query for getting all observations from the database.
+     */
+    private static final String QUERY_GET_OBSERVATIONS =
+            "SELECT * " +
+                    "FROM whimc_observations " +
+                    "WHERE (observation_color_stripped is null or observation_color_stripped = '')";
 
     public Schema_4() {
         super(4, null);
@@ -17,6 +34,18 @@ public class Schema_4 extends SchemaVersion {
     protected void migrateRoutine(Connection connection) throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(ADD_CATEGORY)) {
             statement.execute();
+        }
+
+        try (PreparedStatement statement = connection.prepareStatement(QUERY_UPDATE_OBSERVATION_NO_COLOR)) {
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery(QUERY_GET_OBSERVATIONS);
+            while (rs.next()) {
+                String observation = rs.getString("observation");
+                int rowid = rs.getInt("rowid");
+                statement.setString(1, ChatColor.stripColor(Utils.color(observation)));
+                statement.setInt(2, rowid);
+                statement.execute();
+            }
         }
     }
 

--- a/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
+++ b/src/main/java/edu/whimc/observations/utils/sql/migration/schemas/Schema_4.java
@@ -6,19 +6,20 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-public class Schema_3 extends SchemaVersion {
+public class Schema_4 extends SchemaVersion {
 
-    private static final String REMOVE_FACTUAL =
-            "UPDATE whimc_observations SET category = CASE category WHEN 'FACTUAL' THEN NULL ELSE category END;";
+    private static final String ADD_CATEGORY =
+            "ALTER TABLE whimc_observations ADD COLUMN observation_color_stripped TEXT;";
 
-    public Schema_3() {
-        super(3, new Schema_4());
+    public Schema_4() {
+        super(4, null);
     }
 
     @Override
     protected void migrateRoutine(Connection connection) throws SQLException {
-        try (PreparedStatement statement = connection.prepareStatement(REMOVE_FACTUAL)) {
+        try (PreparedStatement statement = connection.prepareStatement(ADD_CATEGORY)) {
             statement.execute();
         }
     }
+
 }


### PR DESCRIPTION
Changed DB schema for new column for color stripped observation. Fixed bug where templated observations show up twice in db. Before adding new the column, the bukkit strip color method worked perfectly but after left &s and an extra chars so made a little algorithm to fix it (could be cleaner) but will mess up observations if user uses &.