### PR TITLE
Quests objective update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
 	<repositories>
 		<!-- This adds the Spigot Maven repository to the build -->
 		<repository>
+			<id>apache-repo</id>
+			<url>https://mvnrepository.com/artifact/org.apache.commons/commons-lang3</url>
+		</repository>
+		<repository>
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
@@ -27,12 +31,17 @@
 	</repositories>
 
 	<dependencies>
+		<!--Apache Strings Library -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
+		</dependency>
 		<!--This adds the Spigot API artifact to the build -->
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.14.4-R0.1-SNAPSHOT</version>
-			<scope>provided</scope>
+			<version>1.19.2-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!-- Add HolographicDisplays to the build -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.5.1</version>
+	<version>2.5.2</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 
@@ -14,15 +14,10 @@
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
-		<!-- Maven repo for Holographic Displays -->
+		<!-- Maven repo for Holographic Displays and Quests -->
 		<repository>
 			<id>codemc-repo</id>
 			<url>https://repo.codemc.io/repository/maven-public/</url>
-		</repository>
-		<!-- Maven repo for Quests -->
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
 		</repository>
 		<!-- Maven repo for ProtocolLib -->
 		<repository>
@@ -48,9 +43,15 @@
 		</dependency>
 		<!-- Add Quests to the build -->
 		<dependency>
-			<groupId>com.github.PikaMug.Quests</groupId>
-			<artifactId>quests-main</artifactId>
-			<version>4.0.8</version>
+			<groupId>me.blackvein.quests</groupId>
+			<artifactId>quests-api</artifactId>
+			<version>4.5.3</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>me.blackvein.quests</groupId>
+			<artifactId>quests-core</artifactId>
+			<version>4.5.3</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- Add ProtocolLib to the build-->

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.19.2-R0.1-SNAPSHOT</version>
+			<version>1.18.2-R0.1-SNAPSHOT</version>
 		</dependency>
 		<!-- Add HolographicDisplays to the build -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,27 +48,23 @@
 			<groupId>com.gmail.filoghost.holographicdisplays</groupId>
 			<artifactId>holographicdisplays-api</artifactId>
 			<version>2.4.0</version>
-			<scope>provided</scope>
 		</dependency>
 		<!-- Add Quests to the build -->
 		<dependency>
 			<groupId>me.blackvein.quests</groupId>
 			<artifactId>quests-api</artifactId>
 			<version>4.5.3</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>me.blackvein.quests</groupId>
 			<artifactId>quests-core</artifactId>
 			<version>4.5.3</version>
-			<scope>provided</scope>
 		</dependency>
 		<!-- Add ProtocolLib to the build-->
 		<dependency>
 			<groupId>com.comphenix.protocol</groupId>
 			<artifactId>ProtocolLib</artifactId>
 			<version>4.7.0</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
+++ b/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
@@ -3,7 +3,7 @@ package edu.whimc.observations.commands;
 import edu.whimc.observations.Observations;
 import edu.whimc.observations.models.Observation;
 import edu.whimc.observations.utils.Utils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -38,7 +38,7 @@ public class Observation {
     private Hologram hologram;
     private Timestamp expiration;
 
-    private Material hologramItem = Material.LIGHT;
+    private Material hologramItem = Material.NETHER_STAR;
 
     protected Observation(Observations plugin, int id, Timestamp timestamp, String playerName,
                           Location viewLoc, String observation, Timestamp expiration, ObservationTemplate template,

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -37,7 +37,8 @@ public class Observation {
     private int id;
     private Hologram hologram;
     private Timestamp expiration;
-    private Material hologramItem = Material.OAK_SIGN;
+
+    private Material hologramItem = Material.LIGHT;
 
     protected Observation(Observations plugin, int id, Timestamp timestamp, String playerName,
                           Location viewLoc, String observation, Timestamp expiration, ObservationTemplate template,

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -38,7 +38,7 @@ public class Observation {
     private Hologram hologram;
     private Timestamp expiration;
 
-    private Material hologramItem = Material.NETHER_STAR;
+    private Material hologramItem = Material.BIRCH_SIGN;
 
     protected Observation(Observations plugin, int id, Timestamp timestamp, String playerName,
                           Location viewLoc, String observation, Timestamp expiration, ObservationTemplate template,

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -38,7 +38,7 @@ public class Observation {
     private Hologram hologram;
     private Timestamp expiration;
 
-    private Material hologramItem = Material.BIRCH_SIGN;
+    private Material hologramItem = Material.OAK_SIGN;
 
     protected Observation(Observations plugin, int id, Timestamp timestamp, String playerName,
                           Location viewLoc, String observation, Timestamp expiration, ObservationTemplate template,

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
@@ -7,7 +7,7 @@ import edu.whimc.observations.observetemplate.TemplateManager;
 import edu.whimc.observations.observetemplate.models.ObservationTemplate;
 import edu.whimc.observations.observetemplate.models.ObservationType;
 import edu.whimc.observations.utils.Utils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.HoverEvent.Action;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/edu/whimc/observations/observetemplate/models/ObservationType.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/models/ObservationType.java
@@ -1,6 +1,6 @@
 package edu.whimc.observations.observetemplate.models;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public enum ObservationType {
 


### PR DESCRIPTION
Allows our plugins to work as custom quest objectives with the latest version of Quests and Minecraft 1.19. Updates libraries to work with all recent block types so holograms can have any block above them. 