### PR TITLE
Additional config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ If the player has the permission `whimc-observations.observe.customresponse`, th
 |---|---|---|
 |`debug`|`boolean`|Enable/disable debug messages (shows queries and other information in console)|
 |`expiration-days`|`integer`|The amount of time (in days) it will take for an observation to expire|
+|`enable-click-to-view`|`boolean`|Whether clicking an observation teleports you to the view point of where it was created. Setting this to `false` also fixes a bug where players collide with and bounce off observations|
 
 #### Example
 ```yaml
 debug: false
 expiration-days: 7
+enable-click-to-view: false
 ```
 
 ### MySQL
@@ -89,12 +91,12 @@ mysql:
 |`template-gui.filler-item`|`Minecraft material`|The item to use for filler spaces in the GUI|
 |`template-gui.inventory-name`|`string`|The name of the inventory used for the GUI|
 |`template-gui.rows`|`integer`|The number of rows that will be in the GUI (Range [1-6])|
-|`template-gui.cancel.enabled`|`boolean` _(Optional, default `true`)_|Whether or not to show this item in the GUI _(default `true`)_|
+|`template-gui.cancel.enabled`|`boolean` _(Optional, default `true`)_|Whether to show this item in the GUI _(default `true`)_|
 |`template-gui.cancel.item`|`Minecraft material`|The item to use for the cancel button|
 |`template-gui.cancel.position`|`integer`|The position of the cancel button|
 |`template-gui.cancel.name`|`string`|The text to display for the cancel button|
 |`template-gui.cancel.lore`|`string list`|The lore of the cancel button|
-|`template-gui.uncategorized.enabled`|`boolean` _(Optional, default `true`)_|Whether or not to show this item in the GUI _(default `true`)_|
+|`template-gui.uncategorized.enabled`|`boolean` _(Optional, default `true`)_|Whether to show this item in the GUI _(default `true`)_|
 |`template-gui.uncategorized.item`|`Minecraft material`|The item to use for the uncategorized observation button|
 |`template-gui.uncategorized.position`|`integer`|The position of the uncategorized button|
 |`template-gui.uncategorized.name`|`string`|The text to display for the uncategorized button|

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.5.1</version>
+	<version>2.5.2</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/src/main/java/edu/whimc/observations/utils/Utils.java
+++ b/src/main/java/edu/whimc/observations/utils/Utils.java
@@ -220,7 +220,8 @@ public class Utils {
     public static Material matchMaterial(Observations plugin, String materialName, Material fallback) {
         Material material = Material.matchMaterial(materialName);
         if (material == null) {
-            plugin.getLogger().warning(Utils.color("&cUnknown material '&4" + materialName + "&c'! replacing with STONE."));
+            plugin.getLogger().warning(
+                    Utils.color("&cUnknown material '&4" + materialName + "&c'! replacing with " + fallback + "."));
             return fallback;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@
 
 debug: false
 expiration-days: 7
+enable-click-to-view: true
 mysql:
   host: localhost
   port: 3306


### PR DESCRIPTION
* `enable-click-to-view` controls whether clicking an observation will teleport the player to the original view when the observation was created
* Uncategorized observations now use the item of `template-gui.uncategorized.item` instead of defaulting to `OAK_SIGN`