### PR TITLE
Revert back to older version of Spigot API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-Observations</artifactId>
-	<version>2.5.3</version>
+	<version>2.5.4</version>
 	<name>WHIMC Observations</name>
 	<description>Create holographic observations in worlds</description>
 
 	<repositories>
 		<!-- This adds the Spigot Maven repository to the build -->
-		<repository>
-			<id>apache-repo</id>
-			<url>https://mvnrepository.com/artifact/org.apache.commons/commons-lang3</url>
-		</repository>
 		<repository>
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -31,40 +27,39 @@
 	</repositories>
 
 	<dependencies>
-		<!--Apache Strings Library -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.12.0</version>
-		</dependency>
 		<!--This adds the Spigot API artifact to the build -->
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18.2-R0.1-SNAPSHOT</version>
+			<version>1.14.4-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Add HolographicDisplays to the build -->
 		<dependency>
 			<groupId>com.gmail.filoghost.holographicdisplays</groupId>
 			<artifactId>holographicdisplays-api</artifactId>
 			<version>2.4.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Add Quests to the build -->
 		<dependency>
 			<groupId>me.blackvein.quests</groupId>
 			<artifactId>quests-api</artifactId>
 			<version>4.5.3</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>me.blackvein.quests</groupId>
 			<artifactId>quests-core</artifactId>
 			<version>4.5.3</version>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Add ProtocolLib to the build-->
 		<dependency>
 			<groupId>com.comphenix.protocol</groupId>
 			<artifactId>ProtocolLib</artifactId>
 			<version>4.7.0</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
+++ b/src/main/java/edu/whimc/observations/commands/ObserveCommand.java
@@ -3,7 +3,7 @@ package edu.whimc.observations.commands;
 import edu.whimc.observations.Observations;
 import edu.whimc.observations.models.Observation;
 import edu.whimc.observations.utils.Utils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/edu/whimc/observations/models/Observation.java
+++ b/src/main/java/edu/whimc/observations/models/Observation.java
@@ -39,6 +39,7 @@ public class Observation {
     private Hologram hologram;
     private Timestamp expiration;
     private Material hologramItem;
+
     protected Observation(Observations plugin, int id, Timestamp timestamp, String playerName,
                           Location viewLoc, String observation, Timestamp expiration, ObservationTemplate template,
                           boolean isTemporary, boolean isNew) {

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateGui.java
@@ -7,7 +7,7 @@ import edu.whimc.observations.observetemplate.TemplateManager;
 import edu.whimc.observations.observetemplate.models.ObservationTemplate;
 import edu.whimc.observations.observetemplate.models.ObservationType;
 import edu.whimc.observations.utils.Utils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/gui/TemplateSelection.java
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.HoverEvent.Action;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/edu/whimc/observations/observetemplate/models/ObservationType.java
+++ b/src/main/java/edu/whimc/observations/observetemplate/models/ObservationType.java
@@ -1,6 +1,6 @@
 package edu.whimc.observations.observetemplate.models;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 public enum ObservationType {
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ${project.artifactId}
 version: ${project.version}
 description: ${project.description}
 author: Jack Henhapl
-api-version: 1.13
+api-version: 1.14
 main: edu.whimc.observations.Observations
 load: POSTWORLD
 depend: [HolographicDisplays, ProtocolLib]


### PR DESCRIPTION
Switches back to using Spigot 1.14 as our API version. We're not using anything offered in the newer API so let's stick with the oldest compatible version.